### PR TITLE
'Assertion px != 0 failed' error fix

### DIFF
--- a/src/scxml_parser.cpp
+++ b/src/scxml_parser.cpp
@@ -36,10 +36,10 @@ void scxml_parser::parse_scxml(const ptree &pt)
 		for (ptree::const_iterator it = pt.begin(); it != pt.end(); ++it) {
 			if (it->first == "<xmlcomment>") ; // ignore comments
 			else if (it->first == "<xmlattr>") ; // ignore, parsed above
-			else if (it->first == "state") parse_state(it->second, boost::shared_ptr<state>());
-			else if (it->first == "history") parse_state(it->second, boost::shared_ptr<state>());
-			else if (it->first == "final") parse_final(it->second, boost::shared_ptr<state>());
-			else if (it->first == "parallel") parse_parallel(it->second, boost::shared_ptr<state>());
+			else if (it->first == "state") parse_state(it->second, boost::shared_ptr<state>(new state));
+			else if (it->first == "history") parse_state(it->second, boost::shared_ptr<state>(new state));
+			else if (it->first == "final") parse_final(it->second, boost::shared_ptr<state>(new state));
+			else if (it->first == "parallel") parse_parallel(it->second, boost::shared_ptr<state>(new state));
 			else if (it->first == "initial") m_scxml.initial = parse_initial(it->second);
 			else if (it->first == "datamodel") m_scxml.datamodel = parse_datamodel(it->second);
 			else cerr << "warning: unknown item '" << it->first << "' in <scxml>" << endl;


### PR DESCRIPTION
Error rise when some elements, for example <final> was put in the root of <scxml> content;
Example
[test.zip](https://github.com/jp-embedded/scxmlcc/files/895699/test.zip)
