### PR TITLE
debug: demangle the typeid(x).name() output

### DIFF
--- a/src/examples/makefile
+++ b/src/examples/makefile
@@ -16,7 +16,7 @@
 #*************************************************************************
 
 CPPFLAGS := -Wall -O2 -MD -MP
-
+CXXFLAGS := -std=c++11
 APPS := timer_switch hello_world microwave vending_machine/vending_machine
 
 timer_switch.objs := timer_switch.o

--- a/src/makefile
+++ b/src/makefile
@@ -17,6 +17,7 @@
 
 OBJS := main.o cpp_output.o scxml_parser.o version.o
 CPPFLAGS := -Wall -MD -MP -O2
+CXXFLAGS := -std=c++11
 
 all: scxmlcc
 


### PR DESCRIPTION
This makes debug output easier to read.
Instead of this:
```
$ ./vending_machine/vending_machine 
input:  1 = coke button
        2 = zero button
        3 = light button
        c = cancel button
        n = insert nickel
        d = insert dime
        q = quit
sc_vending_machine: transition N18sc_vending_machine5scxmlE -> N18sc_vending_machine10state_initE
sc_vending_machine: enter N18sc_vending_machine10state_initE
sc_vending_machine: transition N18sc_vending_machine10state_initE -> N18sc_vending_machine12state_activeE
sc_vending_machine: exit N18sc_vending_machine10state_initE
sc_vending_machine: enter N18sc_vending_machine12state_activeE
sc_vending_machine: transition N18sc_vending_machine12state_activeE -> N18sc_vending_machine19state_collect_coinsE
sc_vending_machine: enter N18sc_vending_machine19state_collect_coinsE
display: insert coins: 0
```
You get this:
```
$ ./vending_machine/vending_machine 
input:  1 = coke button
        2 = zero button
        3 = light button
        c = cancel button
        n = insert nickel
        d = insert dime
        q = quit
sc_vending_machine: transition sc_vending_machine::scxml -> sc_vending_machine::state_init
sc_vending_machine: enter sc_vending_machine::state_init
sc_vending_machine: transition sc_vending_machine::state_init -> sc_vending_machine::state_active
sc_vending_machine: exit sc_vending_machine::state_init
sc_vending_machine: enter sc_vending_machine::state_active
sc_vending_machine: transition sc_vending_machine::state_active -> sc_vending_machine::state_collect_coins
sc_vending_machine: enter sc_vending_machine::state_collect_coins
display: insert coins: 0
```