### PR TITLE
Add option to ignore xml elements

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,9 +40,9 @@ void scxmlcc(const options &opt)
 {
 	ptree pt;
 	read_xml(opt.input.string(), pt);
-    std::string sc_name = opt.input.stem().string();
+	std::string sc_name = opt.input.stem().string();
 	replace_if(sc_name.begin(), sc_name.end(), c_pred, '_');
-	scxml_parser sc(sc_name.c_str(), pt);
+	scxml_parser sc(sc_name.c_str(), opt.ignore_unknown, pt);
 	ofstream ofs(opt.output.string().c_str());
 	cpp_output out(ofs, sc, opt);
 	out.gen();
@@ -57,6 +57,7 @@ int main(int argc, char *argv[])
 		("input,i",	value<string>(),	"Input file.")
 		("output,o",	value<string>(),	"Output file.")
 		("debug,d",				"Enable debug output")
+		("ignore-unknown,u",	value<string>(),	"ignore unknown xml elements matching regex")
 		("baremetal,b",				"Generate code for bare metal C++")
 		("version,v",				"Version and copyright information");
 	positional_options_description pdesc;
@@ -76,6 +77,7 @@ int main(int argc, char *argv[])
 
 	if(vm.count("input")) opt.input = vm["input"].as<string>();
 	if(vm.count("output")) opt.output = vm["output"].as<string>();
+	if(vm.count("ignore-unknown")) opt.ignore_unknown = vm["ignore-unknown"].as<string>();
 	if(vm.count("debug")) opt.debug = true;
 	if(vm.count("baremetal")) opt.bare_metal = true;
 

--- a/src/options.h
+++ b/src/options.h
@@ -24,6 +24,7 @@ struct options
 {
 	boost::filesystem::path input;
 	boost::filesystem::path output;
+	std::string ignore_unknown;
 	bool debug;
 	bool bare_metal;
 

--- a/src/scxml_parser.cpp
+++ b/src/scxml_parser.cpp
@@ -47,6 +47,7 @@ void scxml_parser::parse_scxml(const ptree &pt)
 			else if (it->first == "parallel") parse_parallel(it->second, boost::shared_ptr<state>());
 			else if (it->first == "initial") m_scxml.initial = parse_initial(it->second);
 			else if (it->first == "datamodel") m_scxml.datamodel = parse_datamodel(it->second);
+			else if (std::regex_match(it->first, ignore_elements_re)) ; // ignore
 			else cerr << "warning: unknown item '" << it->first << "' in <scxml>" << endl;
 		}
 		if(m_scxml.initial.target.size() > 1) parallel_target_sizes.insert(m_scxml.initial.target.size());
@@ -93,6 +94,7 @@ void scxml_parser::parse_parallel(const ptree &pt, const boost::shared_ptr<state
 			else if (it->first == "onentry") st->entry_actions += parse_entry(it->second);
 			else if (it->first == "onexit") st->exit_actions += parse_entry(it->second);
 			else if (it->first == "initial") st->initial = parse_initial(it->second);
+			else if (std::regex_match(it->first, ignore_elements_re)) ; // ignore
 			else cerr << "warning: unknown item '" << it->first << "' in <parallel>" << endl;
 		}
 
@@ -121,6 +123,7 @@ boost::shared_ptr<scxml_parser::data> scxml_parser::parse_data(const ptree &pt)
 		for (ptree::const_iterator it = pt.begin(); it != pt.end(); ++it) {
 			if (it->first == "<xmlcomment>") ; // ignore comments
 			else if (it->first == "<xmlattr>") ; // ignore, parsed above
+			else if (std::regex_match(it->first, ignore_elements_re)) ; // ignore
 			else cerr << "warning: unknown item '" << it->first << "' in <data>" << endl;
 		}
 
@@ -140,6 +143,7 @@ scxml_parser::data_list scxml_parser::parse_datamodel(const ptree &pt)
 		for (ptree::const_iterator it = pt.begin(); it != pt.end(); ++it) {
 			if (it->first == "<xmlcomment>") ; // ignore comments
 			else if (it->first == "data") datamodel.push_back(parse_data(it->second));
+			else if (std::regex_match(it->first, ignore_elements_re)) ; // ignore
 			else cerr << "warning: unknown item '" << it->first << "' in <datamodel>" << endl;
 		}
 
@@ -161,6 +165,7 @@ scxml_parser::transition scxml_parser::parse_initial(const ptree &pt)
 		for (ptree::const_iterator it = pt.begin(); it != pt.end(); ++it) {
 			if (it->first == "<xmlcomment>") ; // ignore comments
 			else if (it->first == "transition") initial = *parse_transition(it->second);
+			else if (std::regex_match(it->first, ignore_elements_re)) ; // ignore
 			else cerr << "warning: unknown item '" << it->first << "' in <initial>" << endl;
 		}
 
@@ -200,6 +205,7 @@ void scxml_parser::parse_state(const ptree &pt, const boost::shared_ptr<state> &
 			else if (it->first == "onexit") st->exit_actions += parse_entry(it->second);
 			else if (it->first == "initial") st->initial = parse_initial(it->second);
 			else if (it->first == "datamodel") { scxml_parser::data_list m = parse_datamodel(it->second); m_scxml.datamodel.insert(m_scxml.datamodel.end(), m.begin(), m.end()); }
+			else if (std::regex_match(it->first, ignore_elements_re)) ; // ignore
 			else cerr << "warning: unknown item '" << it->first << "' in <state>" << endl;
 		}
 
@@ -234,6 +240,7 @@ void scxml_parser::parse_final(const ptree &pt, const boost::shared_ptr<state> &
 			else if (it->first == "<xmlattr>") ; // ignore, parsed above
 			else if (it->first == "onentry") st->entry_actions += parse_entry(it->second);
 			else if (it->first == "onexit") st->exit_actions += parse_entry(it->second);
+			else if (std::regex_match(it->first, ignore_elements_re)) ; // ignore
 			else cerr << "warning: unknown item '" << it->first << "' in <state>" << endl;
 		}
 
@@ -259,6 +266,7 @@ scxml_parser::plist<scxml_parser::action> scxml_parser::parse_entry(const ptree 
 			else if (it->first == "log") l_ac.push_back(parse_log(it->second));
 			else if (it->first == "raise") l_ac.push_back(parse_raise(it->second));
 			else if (it->first == "assign") l_ac.push_back(parse_assign(it->second));
+			else if (std::regex_match(it->first, ignore_elements_re)) ; // ignore
 			else cerr << "warning: unknown item '" << it->first << "' in <onentry> or <onexit>" << endl;
 		}
 	}
@@ -283,6 +291,7 @@ boost::shared_ptr<scxml_parser::action> scxml_parser::parse_raise(const ptree &p
 		for (ptree::const_iterator it = pt.begin(); it != pt.end(); ++it) {
 			if (it->first == "<xmlcomment>") ; // ignore comments
 			else if (it->first == "<xmlattr>") ; // ignore, parsed above
+			else if (std::regex_match(it->first, ignore_elements_re)) ; // ignore
 			else cerr << "warning: unknown item '" << it->first << "' in <raise>" << endl;
 		}
 	}
@@ -311,6 +320,7 @@ boost::shared_ptr<scxml_parser::action> scxml_parser::parse_log(const ptree &pt)
 		for (ptree::const_iterator it = pt.begin(); it != pt.end(); ++it) {
 			if (it->first == "<xmlcomment>") ; // ignore comments
 			else if (it->first == "<xmlattr>") ; // ignore, parsed above
+			else if (std::regex_match(it->first, ignore_elements_re)) ; // ignore
 			else cerr << "warning: unknown item '" << it->first << "' in <log>" << endl;
 		}
 	}
@@ -339,6 +349,7 @@ boost::shared_ptr<scxml_parser::action> scxml_parser::parse_assign(const ptree &
 		for (ptree::const_iterator it = pt.begin(); it != pt.end(); ++it) {
 			if (it->first == "<xmlcomment>") ; // ignore comments
 			else if (it->first == "<xmlattr>") ; // ignore, parsed above
+			else if (std::regex_match(it->first, ignore_elements_re)) ; // ignore
 			else cerr << "warning: unknown item '" << it->first << "' in <assign>" << endl;
 		}
 	}
@@ -360,6 +371,7 @@ boost::shared_ptr<scxml_parser::action> scxml_parser::parse_script(const ptree &
 		for (ptree::const_iterator it = pt.begin(); it != pt.end(); ++it) {
 			if (it->first == "<xmlcomment>") ; // ignore comments
 			else if (it->first == "<xmlattr>") ; // ignore, parsed above
+			else if (std::regex_match(it->first, ignore_elements_re)) ; // ignore
 			else cerr << "warning: unknown item '" << it->first << "' in <script>" << endl;
 		}
 	}
@@ -393,6 +405,7 @@ boost::shared_ptr<scxml_parser::transition> scxml_parser::parse_transition(const
 			else if (it->first == "log") tr->actions.push_back(parse_log(it->second));
 			else if (it->first == "raise") tr->actions.push_back(parse_raise(it->second));
 			else if (it->first == "assign") tr->actions.push_back(parse_assign(it->second));
+			else if (std::regex_match(it->first, ignore_elements_re)) ; // ignore
 			else cerr << "warning: unknown item '" << it->first << "' in <transition>" << endl;
 		}
 	}
@@ -409,11 +422,12 @@ void scxml_parser::parse(const ptree &pt)
 	for (ptree::const_iterator it = pt.begin(); it != pt.end(); ++it) {
 		if (it->first == "<xmlcomment>") ; // ignore comments
 		else if (it->first == "scxml") parse_scxml(it->second);
+		else if (std::regex_match(it->first, ignore_elements_re)) ; // ignore
 		else cerr << "warning: unknown item '" << it->first << "'" << endl;
 	}
 }
 
-scxml_parser::scxml_parser(const char *name, const ptree &pt) : using_parallel(false), using_final(false), using_event_queue(false), using_log(false), using_compound(false), using_transition_no_target(false)
+scxml_parser::scxml_parser(const char *name, const std::string& ignore_unknown, const ptree &pt) : using_parallel(false), using_final(false), using_event_queue(false), using_log(false), using_compound(false), using_transition_no_target(false), ignore_elements_re(ignore_unknown)
 {
 	m_scxml.name = name;
 	parse(pt);

--- a/src/scxml_parser.h
+++ b/src/scxml_parser.h
@@ -25,6 +25,7 @@
 #include <list>
 #include <set>
 #include <map>
+#include <regex>
 
 class scxml_parser
 {
@@ -39,6 +40,7 @@ class scxml_parser
 		bool using_compound;
 		bool using_transition_no_target;
 		std::set<int> parallel_target_sizes;
+		std::regex ignore_elements_re;
 
 		struct action {
 			std::string type;
@@ -78,7 +80,7 @@ class scxml_parser
 			data_list datamodel;
 		};
 
-		scxml_parser(const char *name, const boost::property_tree::ptree &pt);
+		scxml_parser(const char *name, const std::string& ignore_unknown, const boost::property_tree::ptree &pt);
 
 		const scxml& sc() const { return m_scxml; }
 


### PR DESCRIPTION
This is useful if the scxml is generated from a graphical editor that adds
xml elements containing screen position info, such as the scxmleditor
plugin in qt-creator. It will insert <qt:editorinfo> elements.

With this commit, you can suppress warning output from scxmlcc:
```
warning: unknown item 'qt:editorinfo' in <scxml>
warning: unknown item 'qt:editorinfo' in <state>
warning: unknown item 'qt:editorinfo' in <transition>
```

With: `scxmlcc -u "qt:.*" foo.scxml`