### PR TITLE
build with cmake

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/test/gtest"]
+	path = src/test/gtest
+	url = https://github.com/google/googletest.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: cpp
+
 sudo: required
 
 matrix:
@@ -22,5 +23,7 @@ before_install:
 compiler:
   - gcc
 
-script: make -C src && make -C src/examples && make -C src/test && ./src/test/test
-
+jobs:
+   include:
+      - script: make -C src && make -C src/examples && make -C src/test && ./src/test/test
+      - script: mkdir build && cd build && cmake .. && make -j4 && ctest -V 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 2.8.11)
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake/Modules )
+add_subdirectory(src)
+
+# prevent the examples and tests libs installing
+macro(install)
+endmacro()
+
+add_subdirectory(src/examples)
+
+enable_testing()
+add_subdirectory(src/test)

--- a/cmake/Modules/scxmlcc_generator.cmake
+++ b/cmake/Modules/scxmlcc_generator.cmake
@@ -1,0 +1,28 @@
+function (scxmlcc_generator filename gen-list )
+
+   # if we didn't compile the scxmlcc, then go find it in the system
+   if ( TARGET scxmlcc )
+      set(SCC scxmlcc )
+   else()
+      find_program( SCC scxmlcc )
+   endif()
+   
+   get_filename_component(ext ${filename} EXT)
+   if(NOT ext STREQUAL ".scxml")
+      message("skipping ${filename}") 
+      return()
+   endif()
+
+   get_filename_component(base ${filename} NAME_WE)
+   set(output ${CMAKE_CURRENT_BINARY_DIR}/${base}.h)
+   
+   set_source_files_properties(${output} PROPERTIES GENERATED TRUE)
+   set(${gen-list} ${${gen-list}} ${output} PARENT_SCOPE)
+   
+   add_custom_command(
+        OUTPUT ${output}
+        COMMAND ${SCC} -i ${filename}  -o ${output} 
+        DEPENDS ${filename}
+   )
+
+endfunction()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 2.8.11)
+project( scxmlcc )
+
+find_package (Boost REQUIRED COMPONENTS filesystem system program_options )
+
+add_executable( ${PROJECT_NAME}
+   cpp_output.cpp
+   main.cpp
+   scxml_parser.cpp
+   version_git.cpp
+   )
+
+target_include_directories( ${PROJECT_NAME} PRIVATE 
+   ${CMAKE_BINARY_DIR} 
+   ${Boost_INCLUDE_DIR} )
+
+target_link_libraries( ${PROJECT_NAME} PRIVATE
+   ${Boost_LIBRARIES} )
+
+set_property(TARGET ${PROJECT_NAME} 
+   PROPERTY CXX_STANDARD 11)
+
+install(TARGETS ${PROJECT_NAME} 
+   DESTINATION bin)
+
+install(FILES   ${CMAKE_SOURCE_DIR}/cmake/Modules/scxmlcc_generator.cmake 
+    DESTINATION share/cmake/Modules )
+
+# create version header file
+find_package(Git)
+execute_process(
+  COMMAND git describe --first-parent --tags
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE GIT_DESCRIBE
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+FILE(WRITE ${CMAKE_BINARY_DIR}/gitversion.h "\#define GITVERSION \"${GIT_DESCRIBE}\"\n")
+

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -1,0 +1,47 @@
+cmake_minimum_required(VERSION 2.8.11)
+
+include( scxmlcc_generator )
+
+set( CMAKE_INCLUDE_CURRENT_DIR ON )
+
+set(S ${CMAKE_CURRENT_SOURCE_DIR} )
+scxmlcc_generator( ${S}/hello_world.scxml hello_gen_src )
+scxmlcc_generator( ${S}/timer_switch.scxml timer_gen_src )
+scxmlcc_generator( ${S}/microwave-01-cplusplus.scxml microwave_gen_src )
+scxmlcc_generator( ${S}/vending_machine/vending_machine.scxml vending_gen_src )
+
+set (CMAKE_CXX_STANDARD 11)
+
+add_executable( hello_world
+    hello_world.cpp
+    ${hello_gen_src} 
+    )
+
+add_executable( timer_switch
+    timer_switch.cpp
+    ${timer_gen_src}
+    )
+
+add_executable( microwave
+    microwave.cpp
+    ${microwave_gen_src}
+    )
+
+add_executable( vending_machine
+    vending_machine/coin_refund.cpp
+    vending_machine/coin_refund.h
+    vending_machine/coin_sensor.cpp
+    vending_machine/coin_sensor.h
+    vending_machine/dispenser.cpp
+    vending_machine/dispenser.h
+    vending_machine/display.cpp
+    vending_machine/display.h
+    vending_machine/input.cpp
+    vending_machine/input.h
+    vending_machine/keypad.cpp
+    vending_machine/keypad.h
+    vending_machine/machine.h
+    vending_machine/main.cpp
+    vending_machine/signal.h
+    ${vending_gen_src}
+    )

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1,0 +1,45 @@
+cmake_minimum_required(VERSION 2.8.11)
+
+project(tests)
+
+# setup gtest
+add_subdirectory(gtest)
+enable_testing()
+
+set( CMAKE_INCLUDE_CURRENT_DIR ON )
+set( CMAKE_CXX_STANDARD 11 ) 
+
+#generate  txml->scxml->headers
+include( scxmlcc_generator )
+file(GLOB txmls "test*.txml")
+find_program( XSLT xsltproc )
+foreach(file ${txmls})
+   get_filename_component(base ${file} NAME_WE)
+   set(output ${CMAKE_CURRENT_BINARY_DIR}/${base}.scxml)
+   add_custom_command(
+       OUTPUT ${output}
+       COMMAND ${XSLT} ${CMAKE_CURRENT_LIST_DIR}/cpp.xsl ${file} > ${output}
+       DEPENDS ${file}
+       )
+   scxmlcc_generator( ${output} gen_src )
+endforeach()
+
+#generate  scxml->headers
+scxmlcc_generator( ${CMAKE_CURRENT_SOURCE_DIR}/event_list.scxml gen_src )
+scxmlcc_generator( ${CMAKE_CURRENT_SOURCE_DIR}/event_tokens.scxml gen_src )
+scxmlcc_generator( ${CMAKE_CURRENT_SOURCE_DIR}/conditional.scxml gen_src )
+
+add_executable( test_scxml
+    ${gen_src}
+    test.cpp
+    test_t.cpp
+    )
+
+# includes and libs
+target_link_libraries( test_scxml gtest gtest_main )
+target_include_directories( test_scxml PRIVATE
+    ${gtest_SOURCE_DIR}/include 
+    ${gtest_SOURCE_DIR}
+    )
+
+add_test(txml_tests test_scxml)

--- a/src/test/makefile
+++ b/src/test/makefile
@@ -16,7 +16,7 @@
 #*************************************************************************
 
 CPPFLAGS := -Wall -Wpedantic -O2 -MD -MP
-CPPFLAGS += -std=c++17 -isystem gtest-1.7.0/include -pthread
+CPPFLAGS += -std=c++11 -isystem gtest-1.7.0/include -pthread
 
 test.objs := test.o
 test_t.objs := test_t.o
@@ -49,5 +49,5 @@ include gtest.mk
 
 # Initial depedency files must be generated to be able to auto generate .h from .scxml
 %.d: %.cpp
-	$(CXX) -std=c++17 -MM -MG $^ > $@
+	$(CXX) -std=c++11 -MM -MG $^ > $@
 

--- a/src/version_git.cpp
+++ b/src/version_git.cpp
@@ -1,0 +1,27 @@
+/*************************************************************************
+ ** Copyright (C) 2013 Jan Pedersen <jp@jp-embedded.com>
+ ** 
+ ** This program is free software: you can redistribute it and/or modify
+ ** it under the terms of the GNU General Public License as published by
+ ** the Free Software Foundation, either version 3 of the License, or
+ ** (at your option) any later version.
+ ** 
+ ** This program is distributed in the hope that it will be useful,
+ ** but WITHOUT ANY WARRANTY; without even the implied warranty of
+ ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ ** GNU General Public License for more details.
+ ** 
+ ** You should have received a copy of the GNU General Public License
+ ** along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *************************************************************************/
+
+#include "version.h"
+#include "gitversion.h"
+
+static const char _version[] = GITVERSION ;
+
+const char* version()
+{
+	return _version;
+}
+


### PR DESCRIPTION
Adds 
 - cmake build files for scxmlcc, examples and tests cases
 - install a cmake module  which makes using scxmlcc a bit easier for consuming cmake projects
 - update travis to build with both the makefile and cmake method
 - checkout google test as a submodule

Other ideas,

I could move all the cmake files to a separate cmake folder so they aren't scatter amongst the exiting directories, not sure what you think?

Currently the generation of the version header is done differently for windows and unix.  I wanted to auto generate the same version in the cmake project - so I'm simply using 'git-describe' to generate teh version.  There's obviously a good reason why your doing this differently in windows, so I've created a new file 'gitversion.h' to avoid messing up any existing version generation in the makefile.

