### PR TITLE
fix code generation for internal events (<raise>)

### DIFF
--- a/src/cpp_output.cpp
+++ b/src/cpp_output.cpp
@@ -1035,8 +1035,8 @@ void cpp_output::gen_action_part_raise(scxml_parser::action &a)
 	const string ev = a.attr["event"];
 
 	//out << tab << tab << "// " << a.type << " event=" << ev << endl;
-	if (!opt.thread_safe) out << tab << tab << "event_queue.emplace_back(&" << classname() << "::state::event_" << ev << ");" << endl;
-	else out << tab << tab << "push_event(&" << classname() << "::state::event_" << ev << ");" << endl;
+	if (!opt.thread_safe) out << tab << tab << "event_queue.emplace_back(&" << classname() << "::state::" <<  event_name(ev)  << ");" << endl;
+	else out << tab << tab << "push_event(&" << classname() << "::state::" <<  event_name(ev) << ");" << endl;
 }
 
 void cpp_output::gen_action_part(scxml_parser::action &a)


### PR DESCRIPTION
Internal events with '.' in the name lead to code like this: `event_queue.emplace_back(&sc_hello_world::state::event_foo.bar);` because the `'.'` in the event name are not replaced by `'_'`
This pull request fixes it.

Sample scxml:
```
<scxml initial="hello" version="0.9" xmlns="http://www.w3.org/2005/07/scxml">
 <state id="hello">
  <onentry>
   <log expr="Hello" />
   <raise event="foo.bar"/>
  </onentry>
   <transition target="world" event="foo.bar"></transition>
 </state>
 <state id="world"></state>
</scxml>
```
