### PR TITLE
add support for <script> in <scxml>

### DIFF
--- a/src/cpp_output.cpp
+++ b/src/cpp_output.cpp
@@ -1251,6 +1251,16 @@ void cpp_output::gen()
 	}
 	out << endl;
 
+	if(! sc.sc().scripts.empty()) {
+		out << "// user initialisations" << endl;
+		for(const auto script : sc.sc().scripts) {
+			// this would work, but ugly indention:
+			// gen_action_part(*script);
+			out << script->attr["expr"] << endl;
+		}
+		out << endl;
+	}
+
 	if(!opt.ns.empty()) {
 		out << "namespace " << opt.ns << " {" << endl;
 	}

--- a/src/scxml_parser.cpp
+++ b/src/scxml_parser.cpp
@@ -47,6 +47,7 @@ void scxml_parser::parse_scxml(const ptree &pt)
 			else if (it->first == "parallel") parse_parallel(it->second, boost::shared_ptr<state>());
 			else if (it->first == "initial") m_scxml.initial = parse_initial(it->second);
 			else if (it->first == "datamodel") m_scxml.datamodel = parse_datamodel(it->second);
+			else if (it->first == "script") m_scxml.scripts.push_back(parse_script(it->second));
 			else if (std::regex_match(it->first, ignore_elements_re)) ; // ignore
 			else cerr << "warning: unknown item '" << it->first << "' in <scxml>" << endl;
 		}

--- a/src/scxml_parser.h
+++ b/src/scxml_parser.h
@@ -78,6 +78,7 @@ class scxml_parser
 			transition initial;
 			state_list states;
 			data_list datamodel;
+			plist<action> scripts;
 		};
 
 		scxml_parser(const char *name, const std::string& ignore_unknown, const boost::property_tree::ptree &pt);


### PR DESCRIPTION
A better version of https://github.com/jp-embedded/scxmlcc/pull/78.
`#include`, type declarations, etc. can now be added.
Example:
```xml
<scxml initial="hello" version="0.9" xmlns="http://www.w3.org/2005/07/scxml">
  <script>#include &quot;foo.h&quot;</script>
  <script>void hello()
{
  std::cout &lt;&lt; &quot;Hello&quot; &lt;&lt; std::endl;
}</script>
  <state id="hello"/>
</scxml>
```
results in
``` c++
...
// user initialisations
#include "foo.h"
void hello()
{
  std::cout << "Hello" << std::endl;
}
...
```
Closes #63