### PR TITLE
Add cmake DEVELOPER option for building tests and examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,5 @@ compiler:
 jobs:
    include:
       - script: make -C src && make -C src/examples && make -C src/test && ./src/test/test
-      - script: mkdir build && cd build && cmake .. && make -j4 && ctest -V 
+      - script: mkdir build && cd build && cmake .. && make -j4
+      - script: mkdir build-dev && cd build-dev && cmake -DDEVELOPER=1 .. && make -j4 && ctest -V 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,10 @@
 cmake_minimum_required(VERSION 2.8.11)
-
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake/Modules )
+
 add_subdirectory(src)
 
-# prevent the examples and tests libs installing
-macro(install)
-endmacro()
-
-add_subdirectory(src/examples)
-
-enable_testing()
-add_subdirectory(src/test)
+if( DEFINED DEVELOPER ) 
+   add_subdirectory(src/examples)
+   enable_testing()
+   add_subdirectory(src/test)
+endif( DEFINED DEVELOPER ) 

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -50,16 +50,25 @@ make
 ```
 #### with cmake 
 ```
-git submodule update --init
 mkdir build
 cd build
 cmake ..
 make -j4
 make install
 ```
+
 If you're not familar with cmake have a look at the supported generators for visual studio, eclipse etc- https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html.
 
 To help with auto-generating state-machines in cmake projects, an scxml_generator.cmake module is installed.  The examples demonstrate how this can be used. 
+
+To build unit tests, and examples run cmake with 
+```
+mkdir build
+cd build
+cmake -DDEVELOPER=1 ..
+make -j4
+make test
+```
 
 ### On Windows
 The solution file `scxmlcc\src\vc2013\vc2013.sln` contain projects to build the scxml compiler and examples. This is for visual studio 2013.

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -2,14 +2,44 @@ cmake_minimum_required(VERSION 2.8.11)
 
 project(tests)
 
-# setup gtest
-add_subdirectory(gtest)
-enable_testing()
+############################################
+# per gtest instructions for cmake inclusion
+# https://github.com/google/googletest/blob/master/googletest/README.md
+
+configure_file(gtest.cmake.in googletest-download/CMakeLists.txt)
+execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+if(result)
+  message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+endif()
+
+execute_process(COMMAND ${CMAKE_COMMAND} --build .
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+if(result)
+  message(FATAL_ERROR "Build step for googletest failed: ${result}")
+endif()
+
+# Prevent overriding the parent project's compiler/linker
+# settings on Windows
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
+# Add googletest directly to our build. This defines
+# the gtest and gtest_main targets.
+add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
+                 ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
+                 EXCLUDE_FROM_ALL)
 
 set( CMAKE_INCLUDE_CURRENT_DIR ON )
 set( CMAKE_CXX_STANDARD 11 ) 
 
-#generate  txml->scxml->headers
+
+############################################
+# Setup scxml tests
+#
+# generate  txml->scxml->headers
+
 include( scxmlcc_generator )
 file(GLOB txmls "test*.txml")
 find_program( XSLT xsltproc )
@@ -39,11 +69,8 @@ add_executable( test_scxml
     test_t.cpp
     )
 
-# includes and libs
-target_link_libraries( test_scxml gtest gtest_main )
-target_include_directories( test_scxml PRIVATE
-    ${gtest_SOURCE_DIR}/include 
-    ${gtest_SOURCE_DIR}
+target_link_libraries(test_scxml 
+	gtest_main
     )
 
-add_test(txml_tests test_scxml)
+add_test(scxml_tests test_scxml)

--- a/src/test/gtest.cmake.in
+++ b/src/test/gtest.cmake.in
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 2.8.2)
+
+project(googletest-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(googletest
+  GIT_REPOSITORY    https://github.com/google/googletest.git
+  GIT_TAG           release-1.8.1
+  SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
+  BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+)


### PR DESCRIPTION
Fetching gtest with git submodules was causing confusion so this is now
done with cmake during the configure step and only for developers.


