### PR TITLE
print description of unhandled exceptions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -134,9 +134,9 @@ int main(int argc, char *argv[])
 	try {
 		scxmlcc(opt);
 	}
-	catch (...) {
-		cerr << "Unandled error!" << endl;
+	catch (const std::exception& exc) {
+		cerr << "Unhandled exception: " << exc.what() << '\n';
 		return 1;
-	}
+  }
 	return 0;
 }


### PR DESCRIPTION
I had a parsing error a while ago, because of a broken scxml file. scxmlcc has quit without telling about the reason. This PR fixes that.