### PR TITLE
scxmlcc_generator.cmake "fails" for subfolder configurations

### DIFF
--- a/cmake/Modules/scxmlcc_generator.cmake
+++ b/cmake/Modules/scxmlcc_generator.cmake
@@ -6,22 +6,22 @@ function (scxmlcc_generator filename gen-list )
    else()
       find_program( SCC scxmlcc )
    endif()
-   
+
    get_filename_component(ext ${filename} EXT)
    if(NOT ext STREQUAL ".scxml")
-      message("skipping ${filename}") 
+      message("skipping ${filename}")
       return()
    endif()
 
    get_filename_component(base ${filename} NAME_WE)
    set(output ${CMAKE_CURRENT_BINARY_DIR}/${base}.h)
-   
+
    set_source_files_properties(${output} PROPERTIES GENERATED TRUE)
    set(${gen-list} ${${gen-list}} ${output} PARENT_SCOPE)
-   
+
    add_custom_command(
         OUTPUT ${output}
-        COMMAND ${SCC} --stringevents -i ${filename}  -o ${output} 
+        COMMAND ${SCC} --stringevents -i ${filename}  -o ${output}
         DEPENDS ${filename}
    )
 

--- a/cmake/Modules/scxmlcc_generator.cmake
+++ b/cmake/Modules/scxmlcc_generator.cmake
@@ -1,4 +1,8 @@
-function (scxmlcc_generator filename gen-list )
+# Generate statemachine from input file
+# Usage:
+#   filename: Name of input file
+#   target: Name of target, which depends on the statemachine
+function (scxmlcc_generator filename target )
 
    # if we didn't compile the scxmlcc, then go find it in the system
    if ( TARGET scxmlcc )
@@ -16,13 +20,22 @@ function (scxmlcc_generator filename gen-list )
    get_filename_component(base ${filename} NAME_WE)
    set(output ${CMAKE_CURRENT_BINARY_DIR}/${base}.h)
 
-   set_source_files_properties(${output} PROPERTIES GENERATED TRUE)
-   set(${gen-list} ${${gen-list}} ${output} PARENT_SCOPE)
-
    add_custom_command(
         OUTPUT ${output}
         COMMAND ${SCC} --stringevents -i ${filename}  -o ${output}
         DEPENDS ${filename}
    )
+
+   # Append hash to avoid problems with same named input files
+   string(MD5 hash ${filename})
+   set(intermediateTarget "scxmlcc_${base}_${hash}")
+
+   add_custom_target(
+        ${intermediateTarget}
+        DEPENDS ${output}
+   )
+
+   add_dependencies(${target} ${intermediateTarget})
+
 
 endfunction()

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -5,33 +5,20 @@ include( scxmlcc_generator )
 set( CMAKE_INCLUDE_CURRENT_DIR ON )
 
 set(S ${CMAKE_CURRENT_SOURCE_DIR} )
-scxmlcc_generator( ${S}/hello_world.scxml hello_gen_src )
-scxmlcc_generator( ${S}/timer_switch.scxml timer_gen_src )
-scxmlcc_generator( ${S}/microwave-01-cplusplus.scxml microwave_gen_src )
-scxmlcc_generator( ${S}/microwave-02-cplusplus.scxml microwave_gen_src )
-scxmlcc_generator( ${S}/vending_machine/vending_machine.scxml vending_gen_src )
 
 set (CMAKE_CXX_STANDARD 17)
 
-add_executable( hello_world
-    hello_world.cpp
-    ${hello_gen_src} 
-    )
+add_executable( hello_world hello_world.cpp )
+scxmlcc_generator( ${S}/hello_world.scxml hello_world )
 
-add_executable( timer_switch
-    timer_switch.cpp
-    ${timer_gen_src}
-    )
+add_executable( timer_switch timer_switch.cpp )
+scxmlcc_generator( ${S}/timer_switch.scxml timer_switch )
 
-add_executable( microwave-01
-    microwave-01.cpp
-    ${microwave_gen_src}
-    )
+add_executable( microwave-01 microwave-01.cpp )
+scxmlcc_generator( ${S}/microwave-01-cplusplus.scxml microwave-01 )
 
-add_executable( microwave-02
-    microwave-02.cpp
-    ${microwave_gen_src}
-    )
+add_executable( microwave-02 microwave-02.cpp )
+scxmlcc_generator( ${S}/microwave-02-cplusplus.scxml microwave-02 )
 
 add_executable( vending_machine
     vending_machine/coin_refund.cpp
@@ -49,5 +36,5 @@ add_executable( vending_machine
     vending_machine/machine.h
     vending_machine/main.cpp
     vending_machine/signal.h
-    ${vending_gen_src}
     )
+scxmlcc_generator( ${S}/vending_machine/vending_machine.scxml vending_machine )

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -41,6 +41,12 @@ set( CMAKE_CXX_STANDARD 17 )
 # generate  txml->scxml->headers
 
 include( scxmlcc_generator )
+
+#    test_t.cpp currently disabled because dies not work with scxmlcc_generator
+add_executable( test_scxml
+    test.cpp
+    )
+
 file(GLOB txmls "test*.txml")
 find_program( XSLT xsltproc )
 foreach(file ${txmls})
@@ -51,30 +57,25 @@ foreach(file ${txmls})
        COMMAND ${XSLT} ${CMAKE_CURRENT_LIST_DIR}/cpp.xsl ${file} > ${output}
        DEPENDS ${file}
        )
-   scxmlcc_generator( ${output} gen_src )
+   scxmlcc_generator( ${output} test_scxml )
 endforeach()
 
 #generate  scxml->headers
-scxmlcc_generator( ${CMAKE_CURRENT_SOURCE_DIR}/event_list.scxml gen_src )
-scxmlcc_generator( ${CMAKE_CURRENT_SOURCE_DIR}/event_tokens.scxml gen_src )
-scxmlcc_generator( ${CMAKE_CURRENT_SOURCE_DIR}/conditional.scxml gen_src )
-scxmlcc_generator( ${CMAKE_CURRENT_SOURCE_DIR}/lcca_parallel.scxml gen_src )
-scxmlcc_generator( ${CMAKE_CURRENT_SOURCE_DIR}/issue_69.scxml gen_src )
-scxmlcc_generator( ${CMAKE_CURRENT_SOURCE_DIR}/issue_72.scxml gen_src )
-scxmlcc_generator( ${CMAKE_CURRENT_SOURCE_DIR}/issue_88.scxml gen_src )
-scxmlcc_generator( ${CMAKE_CURRENT_SOURCE_DIR}/issue_94.scxml gen_src )
-scxmlcc_generator( ${CMAKE_CURRENT_SOURCE_DIR}/issue_97.scxml gen_src )
-scxmlcc_generator( ${CMAKE_CURRENT_SOURCE_DIR}/eventless.scxml gen_src )
-scxmlcc_generator( ${CMAKE_CURRENT_SOURCE_DIR}/stringevents.scxml gen_src )
-scxmlcc_generator( ${CMAKE_CURRENT_SOURCE_DIR}/parallel_exit.scxml gen_src )
+scxmlcc_generator( ${CMAKE_CURRENT_SOURCE_DIR}/event_list.scxml test_scxml )
+scxmlcc_generator( ${CMAKE_CURRENT_SOURCE_DIR}/event_tokens.scxml test_scxml )
+scxmlcc_generator( ${CMAKE_CURRENT_SOURCE_DIR}/conditional.scxml test_scxml )
+scxmlcc_generator( ${CMAKE_CURRENT_SOURCE_DIR}/lcca_parallel.scxml test_scxml )
+scxmlcc_generator( ${CMAKE_CURRENT_SOURCE_DIR}/issue_69.scxml test_scxml )
+scxmlcc_generator( ${CMAKE_CURRENT_SOURCE_DIR}/issue_72.scxml test_scxml )
+scxmlcc_generator( ${CMAKE_CURRENT_SOURCE_DIR}/issue_88.scxml test_scxml )
+scxmlcc_generator( ${CMAKE_CURRENT_SOURCE_DIR}/issue_94.scxml test_scxml )
+scxmlcc_generator( ${CMAKE_CURRENT_SOURCE_DIR}/issue_97.scxml test_scxml )
+scxmlcc_generator( ${CMAKE_CURRENT_SOURCE_DIR}/eventless.scxml test_scxml )
+scxmlcc_generator( ${CMAKE_CURRENT_SOURCE_DIR}/stringevents.scxml test_scxml )
+scxmlcc_generator( ${CMAKE_CURRENT_SOURCE_DIR}/parallel_exit.scxml test_scxml )
 
-add_executable( test_scxml
-    ${gen_src}
-    test.cpp
-    )
-#    test_t.cpp currently disabled because dies not work with scxmlcc_generator
 
-target_link_libraries(test_scxml 
+target_link_libraries(test_scxml
 	gtest_main
     )
 


### PR DESCRIPTION
Hi,

in my build scenario i specify the target in my top level CMakeLists.txt. Within a subfolder i want to use `scxmlcc_generator.cmake` to generate a state machine.

This setup isn't working. I created an example branch [here](https://github.com/jp-embedded/scxmlcc/commit/a24d50031122536d3289db55443c33d49fe44bf0).

During cmake run, the following error message occurs:

```
[marcel@elfin-behlau build]$ cmake -G "Ninja" -DDEVELOPER=ON ..
CMake Warning (dev) in CMakeLists.txt:
  No project() command is present.  The top-level CMakeLists.txt file must
  contain a literal, direct call to the project() command.  Add a line of
  code such as

    project(ProjectName)

  near the top of the file, but after cmake_minimum_required().

  CMake is pretending there is a "project(Project)" command on the first
  line.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in CMakeLists.txt:
  cmake_minimum_required() should be called prior to this top-level project()
  call.  Please see the cmake-commands(7) manual for usage documentation of
  both commands.
This warning is for project developers.  Use -Wno-dev to suppress it.

-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


CMake Deprecation Warning at src/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


-- Found Boost: /usr/lib/cmake/Boost-1.83.0/BoostConfig.cmake (found version "1.83.0") found components: filesystem system program_options
CMake Deprecation Warning at src/examples/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


CMake Deprecation Warning at src/test/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


-- Configuring done (0.0s)
-- Generating done (0.0s)
-- Build files have been written to: /home/marcel/Documents/scxmlcc/build/src/test/googletest-download
[1/9] Creating directories for 'googletest'
[2/9] Performing download step (git clone) for 'googletest'
Cloning into 'googletest-src'...
HEAD is now at 2fe3bd99 Merge pull request #1433 from dsacre/fix-clang-warnings
[3/9] Performing update step for 'googletest'
[4/9] No patch step for 'googletest'
[5/9] No configure step for 'googletest'
[6/9] No build step for 'googletest'
[7/9] No install step for 'googletest'
[8/9] No test step for 'googletest'
[9/9] Completed 'googletest'
CMake Deprecation Warning at build/src/test/googletest-src/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


CMake Deprecation Warning at build/src/test/googletest-src/googlemock/CMakeLists.txt:42 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


CMake Deprecation Warning at build/src/test/googletest-src/googletest/CMakeLists.txt:49 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


CMake Warning (dev) at build/src/test/googletest-src/googletest/cmake/internal_utils.cmake:239 (find_package):
  Policy CMP0148 is not set: The FindPythonInterp and FindPythonLibs modules
  are removed.  Run "cmake --help-policy CMP0148" for policy details.  Use
  the cmake_policy command to set the policy and suppress this warning.

Call Stack (most recent call first):
  build/src/test/googletest-src/googletest/CMakeLists.txt:84 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Found PythonInterp: /usr/bin/python (found version "3.11.8")
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- Configuring done (3.6s)
CMake Error at src/examples/subfolder/CMakeLists.txt:5 (target_sources):
  Cannot find source file:

    /home/marcel/Documents/scxmlcc/build/src/examples/subfolder/microwave-02-cplusplus.h

  Tried extensions .c .C .c++ .cc .cpp .cxx .cu .mpp .m .M .mm .ixx .cppm
  .ccm .cxxm .c++m .h .hh .h++ .hm .hpp .hxx .in .txx .f .F .for .f77 .f90
  .f95 .f03 .hip .ispc


CMake Error at src/examples/CMakeLists.txt:36 (add_library):
  No SOURCES given to target: testlib
```

I'm not sure, why cmake didn't detect/use the `GENERATED TRUE` property here, or what the problem is.

Regarding the modern cmake motto `Everything is a target`, the problem can be fixed  by using an custom intermediate target. Using [add_custom_target](https://cmake.org/cmake/help/latest/command/add_custom_target.html) with a command argument didn't work in a smooth manner, since `The target has no output file and is always considered out of date even if the commands try to create a file with the name of the target.`

The MR changes  the interface of the `scxmlcc_generator` command. Instead of getting the name of the generated file, now the depended target must be passed. This will cause some problems, if the input file should be used in multiple targets. I will address this in an extra MR.

The relevant changes are applied already for the example and test folder.